### PR TITLE
Wire up zipkin stats receivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ This telemeter writes tracing data to zipkin over HTTP. Sample configuration:
 
 ```yaml
 telemetry:
-- kind: io.l5d.commonMetrics
 - kind: io.zipkin.http
   host: localhost:9411
   initialSampleRate: 0.02
@@ -60,7 +59,6 @@ This telemeter writes tracing data to zipkin using Kafka. Sample configuration:
 
 ```yaml
 telemetry:
-- kind: io.l5d.commonMetrics
 - kind: io.zipkin.kafka
   bootstrapServers: localhost:9092
   initialSampleRate: 0.02

--- a/src/main/scala/io/buoyant/linkerd/zipkin/HttpInitializer.scala
+++ b/src/main/scala/io/buoyant/linkerd/zipkin/HttpInitializer.scala
@@ -29,7 +29,7 @@ case class HttpConfig(
 
   def mk(params: Stack.Params): HttpTelemeter = {
     val param.Stats(stats) = params[param.Stats]
-    val tracer = HttpZipkinTracer.create(config, stats.scope("zipkin.http"))
+    val tracer = HttpZipkinTracer.create(config, stats.scope("io.zipkin.http"))
     new HttpTelemeter(tracer)
   }
 }

--- a/src/main/scala/io/buoyant/linkerd/zipkin/HttpInitializer.scala
+++ b/src/main/scala/io/buoyant/linkerd/zipkin/HttpInitializer.scala
@@ -1,6 +1,6 @@
 package io.buoyant.linkerd.zipkin
 
-import com.twitter.finagle.Stack
+import com.twitter.finagle.{Stack, param}
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.Tracer
 import com.twitter.finagle.zipkin.core.Sampler
@@ -20,18 +20,18 @@ case class HttpConfig(
   initialSampleRate: Option[Double]
 ) extends TelemeterConfig {
 
-  private[this] val tracer: Tracer = {
-    val config = HttpZipkinTracer.Config.builder()
-      .host(host.getOrElse("localhost:9411"))
-      .hostHeader(hostHeader.getOrElse("zipkin"))
-      .compressionEnabled(compressionEnabled.getOrElse(true))
-      .initialSampleRate(initialSampleRate.map(_.toFloat).getOrElse(Sampler.DefaultSampleRate))
-      .build()
+  private[this] val config: HttpZipkinTracer.Config = HttpZipkinTracer.Config.builder()
+    .host(host.getOrElse("localhost:9411"))
+    .hostHeader(hostHeader.getOrElse("zipkin"))
+    .compressionEnabled(compressionEnabled.getOrElse(true))
+    .initialSampleRate(initialSampleRate.map(_.toFloat).getOrElse(Sampler.DefaultSampleRate))
+    .build()
 
-    HttpZipkinTracer.create(config, NullStatsReceiver)
+  def mk(params: Stack.Params): HttpTelemeter = {
+    val param.Stats(stats) = params[param.Stats]
+    val tracer = HttpZipkinTracer.create(config, stats.scope("zipkin.http"))
+    new HttpTelemeter(tracer)
   }
-
-  def mk(params: Stack.Params): HttpTelemeter = new HttpTelemeter(tracer)
 }
 
 class HttpTelemeter(underlying: Tracer) extends Telemeter {

--- a/src/main/scala/io/buoyant/linkerd/zipkin/KafkaInitializer.scala
+++ b/src/main/scala/io/buoyant/linkerd/zipkin/KafkaInitializer.scala
@@ -27,7 +27,7 @@ case class KafkaConfig(
 
   def mk(params: Stack.Params): KafkaTelemeter = {
     val param.Stats(stats) = params[param.Stats]
-    val tracer = KafkaZipkinTracer.create(config, stats.scope("zipkin.kafka"))
+    val tracer = KafkaZipkinTracer.create(config, stats.scope("io.zipkin.kafka"))
     new KafkaTelemeter(tracer)
   }
 }


### PR DESCRIPTION
Use the stats receiver provided by the stack when initializing the http and kafka tracers. Fixes #3.