### PR TITLE
Update dependencies to match Finagle 6.44.0 upgrade in linkerd/linkerd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ $ ./sbt assembly
 ```
 
 That will build a linkerd-zipkin plugin jar in `plugins/`. Put that jar in
-linkerd's class path to make the telemeters available.
+linkerd's class path to make the telemeters available. Further information on
+installing plugins is available in the linkerd
+[plugin documentation](https://linkerd.io/in-depth/plugin/#installing).
 
 ### Docker
 
@@ -42,7 +44,6 @@ This telemeter writes tracing data to zipkin over HTTP. Sample configuration:
 
 ```yaml
 telemetry:
-- kind: io.l5d.commonMetrics
 - kind: io.zipkin.http
   host: localhost:9411
   initialSampleRate: 0.02
@@ -63,7 +64,6 @@ This telemeter writes tracing data to zipkin using Kafka. Sample configuration:
 
 ```yaml
 telemetry:
-- kind: io.l5d.commonMetrics
 - kind: io.zipkin.kafka
   bootstrapServers: localhost:9092
   initialSampleRate: 0.02

--- a/build.sbt
+++ b/build.sbt
@@ -5,10 +5,10 @@ def finagle(mod: String) =
   "com.twitter" %% s"finagle-$mod" % "6.44.0"
 
 def telemetery(mod: String) =
-  "io.buoyant" %% s"telemetry-$mod" % "1.0.0"
+  "io.buoyant" %% s"telemetry-$mod" % "1.0.2"
 
 def zipkin(mod: String) =
-  "io.zipkin.finagle" %% s"zipkin-finagle-$mod" % "0.3.6"
+  "io.zipkin.finagle" %% s"zipkin-finagle-$mod" % "0.4.0"
 
 def scalatest() =
   "org.scalatest" %% "scalatest" % "3.0.1"
@@ -18,7 +18,7 @@ val `linkerd-zipkin` =
     .settings(
       organization := "io.buoyant",
       version := "0.0.1",
-      scalaVersion in GlobalScope := "2.11.7",
+      scalaVersion in GlobalScope := "2.12.1",
       ivyScala := ivyScala.value.map(_.copy(overrideScalaVersion = true)),
       resolvers ++= Seq(
         "twitter-repo" at "https://maven.twttr.com",

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,17 @@
 def twitterUtil(mod: String) =
-  "com.twitter" %% s"util-$mod" %  "6.40.0"
+  "com.twitter" %% s"util-$mod" %  "6.43.0"
 
 def finagle(mod: String) =
-  "com.twitter" %% s"finagle-$mod" % "6.41.0"
+  "com.twitter" %% s"finagle-$mod" % "6.44.0"
 
 def telemetery(mod: String) =
   "io.buoyant" %% s"telemetry-$mod" % "0.9.1"
 
 def zipkin(mod: String) =
-  "io.zipkin.finagle" %% s"zipkin-finagle-$mod" % "0.3.4"
+  "io.zipkin.finagle" %% s"zipkin-finagle-$mod" % "0.3.6"
 
 def scalatest() =
-  "org.scalatest" %% "scalatest" % "2.2.4"
+  "org.scalatest" %% "scalatest" % "3.0.1"
 
 val `linkerd-zipkin` =
   project.in(file("."))


### PR DESCRIPTION
Tested against linkerd master and confirmed that spans were being sent as expected.