### PR TITLE
Upgrade to linkerd 1.1.1, finagle 6.45.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buoyantio/linkerd:1.0.2
+FROM buoyantio/linkerd:1.1.1
 
 RUN mkdir -p $L5D_HOME/plugins
 COPY plugins/*.jar $L5D_HOME/plugins

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ def telemetery(mod: String) =
   "io.buoyant" %% s"telemetry-$mod" % "1.1.1"
 
 def zipkin(mod: String) =
-  "io.zipkin.finagle" %% s"zipkin-finagle-$mod" % "0.4.1-SNAPSHOT"
+  "io.zipkin.finagle" %% s"zipkin-finagle-$mod" % "1.0.0"
 
 def scalatest() =
   "org.scalatest" %% "scalatest" % "3.0.1"

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 def twitterUtil(mod: String) =
-  "com.twitter" %% s"util-$mod" %  "6.43.0"
+  "com.twitter" %% s"util-$mod" %  "6.45.0"
 
 def finagle(mod: String) =
-  "com.twitter" %% s"finagle-$mod" % "6.44.0"
+  "com.twitter" %% s"finagle-$mod" % "6.45.0"
 
 def telemetery(mod: String) =
-  "io.buoyant" %% s"telemetry-$mod" % "1.0.2"
+  "io.buoyant" %% s"telemetry-$mod" % "1.1.1"
 
 def zipkin(mod: String) =
-  "io.zipkin.finagle" %% s"zipkin-finagle-$mod" % "0.4.0"
+  "io.zipkin.finagle" %% s"zipkin-finagle-$mod" % "0.4.1-SNAPSHOT"
 
 def scalatest() =
   "org.scalatest" %% "scalatest" % "3.0.1"


### PR DESCRIPTION
We can't merge this until we move to a stable zipkin-finagle release that includes the finagle upgrade from openzipkin/zipkin-finagle@96df1eca4406d55a1d5bc6cccdb9d83012e6e7b9. For now I've tested against a locally-published snapshot and everything is working as expected.