### PR TITLE
Upgrade to linkerd 1.2.1, zipkin-finagle to 1.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buoyantio/linkerd:1.1.1
+FROM buoyantio/linkerd:1.2.1
 
 RUN mkdir -p $L5D_HOME/plugins
 COPY plugins/*.jar $L5D_HOME/plugins

--- a/build.sbt
+++ b/build.sbt
@@ -5,10 +5,10 @@ def finagle(mod: String) =
   "com.twitter" %% s"finagle-$mod" % "6.45.0"
 
 def telemetery(mod: String) =
-  "io.buoyant" %% s"telemetry-$mod" % "1.1.1"
+  "io.buoyant" %% s"telemetry-$mod" % "1.2.1"
 
 def zipkin(mod: String) =
-  "io.zipkin.finagle" %% s"zipkin-finagle-$mod" % "1.0.0"
+  "io.zipkin.finagle" %% s"zipkin-finagle-$mod" % "1.0.1"
 
 def scalatest() =
   "org.scalatest" %% "scalatest" % "3.0.1"


### PR DESCRIPTION
Updated for the latest linkerd release + patch upgrade to the zipkin-finangle dep.