### PR TITLE
Update for compatibility with sbt 1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,9 @@ val `linkerd-zipkin` =
       organization := "io.buoyant",
       version := "0.0.1",
       scalaVersion in GlobalScope := "2.12.1",
-      ivyScala := ivyScala.value.map(_.copy(overrideScalaVersion = true)),
+      scalaModuleInfo := scalaModuleInfo
+        .value
+        .map(_.withOverrideScalaVersion(true)),
       resolvers ++= Seq(
         "twitter-repo" at "https://maven.twttr.com",
         Resolver.mavenLocal,

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,0 +1,2 @@
+// packaging
+addSbtPlugin("com.eed3si9n"      % "sbt-assembly"    % "0.14.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,0 @@
-// packaging
-addSbtPlugin("com.eed3si9n"      % "sbt-assembly"    % "0.14.1")


### PR DESCRIPTION
The project no longer builds with sbt version 1.0. Although `./sbt` appears to specify the sbt version as 0.13.9, it downloads sbt 1.0 regardless (at least on my machine); therefore the project doesn't build out of the box.

I've updated the build script to use a version of the `sbt-assembly` plugin that exists for sbt 1.0. I've also updated the use of the `ivyScala` configuration key to track changes in 1.0: this key was renamed to `scalaModuleInfo` and the API was changed to remove the `.copy` function and replace it with a set of `.with$PARAMETER` functions.

Note that this will probably break the build with earlier sbt versions.