### PR TITLE
Add build.properties to enforce expected sbt version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16


### PR DESCRIPTION
Since the sbt configurations are written usiong sbt 0.13 syntax, I've added a `build.properties` file to ensure that sbt 0.13 is used rather than 1.0. Note that the version set in `.sbt` does _not_ actually configure what sbt version is used; rather, it configures the version of the _sbt launcher_ JAR that is downloaded.

Closes #18.