### PR TITLE
Update linkerd-zipkin to 1.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buoyantio/linkerd:1.6.2
+FROM buoyantio/linkerd:1.6.3
 
 RUN mkdir -p $L5D_HOME/plugins
 COPY plugins/*.jar $L5D_HOME/plugins/

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import sbtassembly.{AssemblyUtils, MergeStrategy}
 
-val linkerdVersion = "1.6.2"
+val linkerdVersion = "1.6.3"
 
 def twitterUtil(mod: String) =
   "com.twitter" %% s"util-$mod" %  "19.1.0"


### PR DESCRIPTION
Subject: Release libraries for linkerd 1.6.3

Problem: N/A Just a new release

Solution: Update build.sbt and Docker file per release process

Validation:

Fixes: #38