### PR TITLE
upgrade linkerd 1.7.0, finagle 19.5.1, io.zipkin.finagle2 2.0.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buoyantio/linkerd:1.6.3
+FROM buoyantio/linkerd:1.7.0
 
 RUN mkdir -p $L5D_HOME/plugins
 COPY plugins/*.jar $L5D_HOME/plugins/

--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,18 @@
 import sbtassembly.{AssemblyUtils, MergeStrategy}
 
-val linkerdVersion = "1.6.3"
+val linkerdVersion = "1.7.0"
 
 def twitterUtil(mod: String) =
-  "com.twitter" %% s"util-$mod" %  "19.1.0"
+  "com.twitter" %% s"util-$mod" %  "19.5.1"
 
 def finagle(mod: String) =
-  "com.twitter" %% s"finagle-$mod" % "19.1.0"
+  "com.twitter" %% s"finagle-$mod" % "19.5.1"
 
 def telemetry(mod: String) =
   "io.buoyant" %% s"telemetry-$mod" % linkerdVersion
 
 def zipkin(mod: String) =
-  "io.zipkin.finagle2" %% s"zipkin-finagle-$mod" % "2.0.10"
+  "io.zipkin.finagle2" %% s"zipkin-finagle-$mod" % "2.0.15"
 
 def scalatest() =
   "org.scalatest" %% "scalatest" % "3.0.1"


### PR DESCRIPTION
These changes brings linkerd-zipkin plugin up-to-date with latest linkerd 1.7.0 dependencies. W/o these changes, trying to start linkerd with linker-zipkin plugin results in a java.lang.ExceptionInInitializerError "Caused by: java.lang.IllegalArgumentException: Multiple differing Toggle config resources found for com.twitter.finagle.core". 

Signed-off-by: dst4096 <dst4096@gmail.com>